### PR TITLE
fixes duplicated bulk paste bar upon reopening menu

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -1,9 +1,9 @@
 {
   "author": "wondible, Cola_Colin",
-  "build": "113044",
+  "build": "116982",
   "category": ["sandbox", "titans"],
   "context": "client",
-  "date": "2020/02/14",
+  "date": "2023/06/28",
   "description": "Adds hotkey for pasting 10 or N units in sandbox mode.",
   "display_name": "Bulk Create Units",
   "forum": "https://forums.uberent.com/threads/rel-bulk-create-units.62492/",
@@ -27,5 +27,5 @@
     ]
   },
   "signature": "not yet implemented",
-  "version": "2.2.0"
+  "version": "2.2.1"
 }

--- a/ui/mods/bulk_create_units/bulk_paste_count.html
+++ b/ui/mods/bulk_create_units/bulk_paste_count.html
@@ -1,4 +1,4 @@
-<div style="display: inline-block">
+<div class = "bulk-paste-container" style="display: inline-block">
   <input type="text" id="bulk-paste-count-slider" class="slider" value="10"
     data-slider-handle="square" data-slider-orientation="horizontal" data-slider-selection="none" data-slider-tooltip="hide" 
     data-bind="slider: { value: bulkPasteSlider, options: bulkPasteOptions }" />

--- a/ui/mods/bulk_create_units/live_game_sandbox.js
+++ b/ui/mods/bulk_create_units/live_game_sandbox.js
@@ -30,7 +30,7 @@
   }
 
   model.sandbox_expanded.subscribe(function(open) {
-    if (!open) return
+    if (!open){ $('.bulk-paste-container').remove(); return}
     addControls()
     api.Panel.message(api.Panel.parentId, 'bulkCreateUnitSandboxExpanded', open)
   })


### PR DESCRIPTION
fixes duplicated bulk paste bar every time you open and close sandbox menu, which prevents proper use

modinfo updated for detection